### PR TITLE
Modify gitattributes for line-ending

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+^\.gitattributes$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,14 @@
-# Auto detect text files and perform LF normalization
+# Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.Rd text eol=lf
+*.R text eol=lf
+*.Rmd text eol=lf
+*.md text eol=lf
+NAMESPACE text eol=lf
+DESCRIPTION text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 SpNuit_GLMsanssel.R
 SpNuit_GLMsanssel.R
+.Rproj.user


### PR DESCRIPTION
Allow multi-platform collaboration while avoiding false file changes due to different Line ending in Windows / Linux / MacOS

closes #12 